### PR TITLE
Fixed Alignment issues

### DIFF
--- a/bin/GetReadCounts.py
+++ b/bin/GetReadCounts.py
@@ -105,17 +105,25 @@ def CountReads(sample):
     print('Loading alignment ...')      
     # CLASSIFY ALIGNMENTS 
     # os.chdir(AlnDir)
-    sam_file = ReadsFilename0 + '.sam' 
-    sam_file_present = path.exists(sam_file)
-    bam_file = ReadsFilename0 + '.bam'
-    bam_file_present = path.exists(bam_file)    
-    if sam_file_present:
-        sam_file = sam_file
-    elif bam_file_present: 
-        os.system('samtools view -h '+bam_file+' > '+sam_file)
-    else:
+    #sam_file = ReadsFilename0 + '.sam' 
+    #sam_file_present = path.exists(sam_file)
+    #bam_file = ReadsFilename0 + '.bam'
+    #bam_file_present = path.exists(bam_file)    
+    #if sam_file_present:
+     #   sam_file = sam_file
+    #elif bam_file_present: 
+    #    os.system('samtools view -h '+bam_file+' > '+sam_file)
+    #else:
+     #   print('### ERROR: No alignment file present ###')
+    #bw2sam = pysam.AlignmentFile(sam_file,'rb')
+        if bam_file_present == False:
         print('### ERROR: No alignment file present ###')
-    bw2sam = pysam.AlignmentFile(sam_file,'rb')
+    BFS = str("bam_file_sorted")
+    pysam.sort("-o", BFS + ".bam", bam_file )
+    pysam.index(BFS + ".bam")  
+    bw2sam = pysam.AlignmentFile(BFS + ".bam",'rb')
+    
+    
     print('Applying matching threshold ...')
     print('Applying ambiguity threshold ...')       
     NFail = 0; NUnique = 0; NTol = 0; NAmb = 0


### PR DESCRIPTION
The reason that pinaplpy does not find any successful reads is because it prioritises the .sam files over .bam files.
I've changed the code a bit to fix the issue temporarily (very sloppy code) and indexed the .bam file with Pysam.



<!--
# nf-core/crisprquant pull request

Many thanks for contributing to nf-core/crisprquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/crisprquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprquant/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/crisprquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
